### PR TITLE
Update for data.table v1.12.0:  retains attributes

### DIFF
--- a/R/behavr.R
+++ b/R/behavr.R
@@ -137,7 +137,7 @@ setbehavr <- function(x, metadata){
   # therefore, we want to from metadata, the id that are not in data
   md <- meta(x)
   if(!inline){
-    unique_ids <- unique(out[, data.table::key(out), with=FALSE])
+    unique_ids <- unique(utils::getS3method("[","data.table")(out, j=data.table::key(out), with=FALSE))  # out is class behavr, so out[...] would recurse here
     mismatches <- md[!unique_ids]
     if(nrow(mismatches) > 0){
       if(verbose ==TRUE){


### PR DESCRIPTION
Hi Quentin,

`[.data.table` in v1.12.0 of data.table now retains user-defined and superclass attributes.  In the case of `behavr` that means `meta` is now retained.   The superclass name (`behavr`) was always retained in `class` but not its attributes such as `meta`.  So line 139 always used to call itself (`[.behavr`) but it worked on the 2nd call because the meta attribute was dropped by `[.data.table`.  Now with v1.12.0, the meta attribute is retained, and `[.behavr` ends up in an infinite recursive loop which eventually ends with a `C stack usage` error.

This PR avoids the recursive call to `[.behavr` by calling `[.data.table` directly.

Hopefully data.table v1.12.0 will go to CRAN in the next week or two. When it does, `behavr` will start to fail on CRAN. Are you ok to merge this PR and update `behavr` on CRAN please?

Best, Matt
